### PR TITLE
fix: update sha integrity checksums in package-lock files for customvis-lib

### DIFF
--- a/code-samples/11.1.x/overlaybar/package-lock.json
+++ b/code-samples/11.1.x/overlaybar/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@businessanalytics/customvis-lib": {
             "version": "file:customvis-lib.tgz",
-            "integrity": "sha512-m7a+f5o96xWN3OY0GuOW50khj0S78EX+MW3D5x5SZ/ouDOlU2DsztlZQOfwiIytydr5vmoap0qmcSs6f5Jc2wQ=="
+            "integrity": "sha512-IDeqyVUQ6Lm6eBoZzD7sL+S4WyxCiRu0DaXO1LhP0h0CO1/jXGPXihjpRBVe/h7jEHVEilDX2Vca9oT+OUxB1A=="
         },
         "@types/d3": {
             "version": "5.7.2",

--- a/code-samples/11.1.x/quadrant/package-lock.json
+++ b/code-samples/11.1.x/quadrant/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@businessanalytics/customvis-lib": {
             "version": "file:customvis-lib.tgz",
-            "integrity": "sha512-m7a+f5o96xWN3OY0GuOW50khj0S78EX+MW3D5x5SZ/ouDOlU2DsztlZQOfwiIytydr5vmoap0qmcSs6f5Jc2wQ=="
+            "integrity": "sha512-IDeqyVUQ6Lm6eBoZzD7sL+S4WyxCiRu0DaXO1LhP0h0CO1/jXGPXihjpRBVe/h7jEHVEilDX2Vca9oT+OUxB1A=="
         },
         "@types/d3": {
             "version": "5.7.2",

--- a/code-samples/11.1.x/sankey/package-lock.json
+++ b/code-samples/11.1.x/sankey/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@businessanalytics/customvis-lib": {
             "version": "file:customvis-lib.tgz",
-            "integrity": "sha512-m7a+f5o96xWN3OY0GuOW50khj0S78EX+MW3D5x5SZ/ouDOlU2DsztlZQOfwiIytydr5vmoap0qmcSs6f5Jc2wQ=="
+            "integrity": "sha512-IDeqyVUQ6Lm6eBoZzD7sL+S4WyxCiRu0DaXO1LhP0h0CO1/jXGPXihjpRBVe/h7jEHVEilDX2Vca9oT+OUxB1A=="
         },
         "@types/d3": {
             "version": "5.7.2",

--- a/code-samples/11.1.x/scatter/package-lock.json
+++ b/code-samples/11.1.x/scatter/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@businessanalytics/customvis-lib": {
             "version": "file:customvis-lib.tgz",
-            "integrity": "sha512-m7a+f5o96xWN3OY0GuOW50khj0S78EX+MW3D5x5SZ/ouDOlU2DsztlZQOfwiIytydr5vmoap0qmcSs6f5Jc2wQ=="
+            "integrity": "sha512-IDeqyVUQ6Lm6eBoZzD7sL+S4WyxCiRu0DaXO1LhP0h0CO1/jXGPXihjpRBVe/h7jEHVEilDX2Vca9oT+OUxB1A=="
         },
         "@types/d3": {
             "version": "5.7.2",

--- a/code-samples/11.1.x/ternary/package-lock.json
+++ b/code-samples/11.1.x/ternary/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@businessanalytics/customvis-lib": {
             "version": "file:customvis-lib.tgz",
-            "integrity": "sha512-m7a+f5o96xWN3OY0GuOW50khj0S78EX+MW3D5x5SZ/ouDOlU2DsztlZQOfwiIytydr5vmoap0qmcSs6f5Jc2wQ=="
+            "integrity": "sha512-IDeqyVUQ6Lm6eBoZzD7sL+S4WyxCiRu0DaXO1LhP0h0CO1/jXGPXihjpRBVe/h7jEHVEilDX2Vca9oT+OUxB1A=="
         },
         "@types/d3": {
             "version": "5.7.2",

--- a/code-samples/11.1.x/weatherkpi/package-lock.json
+++ b/code-samples/11.1.x/weatherkpi/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@businessanalytics/customvis-lib": {
             "version": "file:customvis-lib.tgz",
-            "integrity": "sha512-m7a+f5o96xWN3OY0GuOW50khj0S78EX+MW3D5x5SZ/ouDOlU2DsztlZQOfwiIytydr5vmoap0qmcSs6f5Jc2wQ=="
+            "integrity": "sha512-IDeqyVUQ6Lm6eBoZzD7sL+S4WyxCiRu0DaXO1LhP0h0CO1/jXGPXihjpRBVe/h7jEHVEilDX2Vca9oT+OUxB1A=="
         },
         "@types/d3": {
             "version": "5.7.2",


### PR DESCRIPTION
6 package-lock files kept old integrity checksum for customvis-lib what caused errors for `npm install` attempts.
I updated the checksums so it is valid for actual customvis-lib.tgz files in repo.