### PR TITLE
fix: Add missing tsconfig.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directories
+**/node_modules/

--- a/code-samples/11.1.x/scatter/tsconfig.json
+++ b/code-samples/11.1.x/scatter/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "target": "ES5",
+        "lib": [
+            "dom",
+            "es5",
+            "es2015"
+        ]
+    }
+}


### PR DESCRIPTION
- Add missing tsconfig.json file, which could result of TypeScript compilation errors on recent customvis SDK
- Add node_modules to .gitignore file