### PR TITLE
fix: replace deprecated node-sass with sass

### DIFF
--- a/visualization-samples/11.1.x/decomposition-tree/package.json
+++ b/visualization-samples/11.1.x/decomposition-tree/package.json
@@ -18,7 +18,7 @@
         "@rollup/plugin-json": "4.1.0",
         "@rollup/plugin-replace": "3.0.1",
         "@types/d3": "^5.7.0",
-        "node-sass": "^8.0.0",
+        "sass": "^1.93.2",
         "postcss": "~8.4.31",
         "rollup-plugin-postcss": "4.0.2"
     },


### PR DESCRIPTION
Fix for errors with node-gyp that was a dependency for deprecated node-sass.

Sass has no longer dependency on node-gyp