### PR TITLE
chore: add warning to fusioncharts pareto

### DIFF
--- a/code-samples/11.1.x/fusionchartspareto/README.md
+++ b/code-samples/11.1.x/fusionchartspareto/README.md
@@ -1,5 +1,9 @@
 # FusionCharts Pareto chart code sample
 
+> [!WARNING]
+> Do not use newly built FusionCharts Pareto customvis with Cognos Analytics Dashboard. It can break the application with risk of loss of unsaved work.
+> An existing [customvis.catalog.codesample.fusioncharts-pareto.zip](https://github.com/IBM/ca_customvis/blob/master/code-samples/11.1.x/fusionchartspareto/customvis.catalog.codesample.fusioncharts-pareto.zip) is safe to use.
+
 This FusionCharts Pareto chart example is integrated with Customvis library. A more complete explanation on the library and API using can be found in [Customvis documentation](https://www.ibm.com/support/knowledgecenter/en/SSEP7J_11.1.0/com.ibm.swg.ba.cognos.dg_custom_vis.doc/ca_customviz_lib_summary.html).
 
 For more details on FusionCharts information and options, see the [FusionCharts documentation](https://www.fusioncharts.com/dev/fusioncharts).

--- a/code-samples/11.1.x/fusionchartspareto/rollup.config.js
+++ b/code-samples/11.1.x/fusionchartspareto/rollup.config.js
@@ -24,6 +24,15 @@ const paths = {
 if ( !hasD3Dependency )
     paths[ "d3" ] = "https://d3js.org/d3.v5.min.js";
 
+console.warn(`
+
+    WARNING
+
+    Do not use newly built FusionCharts Pareto customvis with Cognos Analytics Dashboard.
+    It can break the application with risk of loss of unsaved work.
+
+`);
+
 module.exports =
 {
     input,


### PR DESCRIPTION
Added:

1. Warning about possible issues with fusioncharts pareto to README inside this customvis (this description was updated after review):
<img width="1055" height="299" alt="Screenshot 2025-10-07 at 11 49 02" src="https://github.com/user-attachments/assets/1f7d3d14-49df-4fee-a3df-869fbc9dbff4" />

2. Added warning during using `customvis build` or `customvis pack` commands:
<img width="1034" height="227" alt="Screenshot 2025-10-07 at 11 45 27" src="https://github.com/user-attachments/assets/69058623-9e4e-4a0c-a474-b6eeedefbe7c" />

